### PR TITLE
ES6 and JSX support thanks to typhonjs-escomplex.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0 (5/22/2018; Akshat Sharma)
+- ES6 and JSX support thanks to typhonjs-escomplex.
+- Fixed bug in handling --help flag.
+- Updated usage guide.
+- Writing individual json report files.
+
 ## 1.0.0 (5/21/2018; Akshat Sharma)
 Escomplex still seems to be missing ES6; going to try typhonjs-escomplex in the next version.
 

--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -1,0 +1,49 @@
+const escomplex = require('typhonjs-escomplex');
+const path = require('path');
+const fs = require('./fs');
+const { getCommandLineArgs } = require('./get-command-line-args');
+const {
+  errorLogger,
+  logger,
+  passThrough,
+} = require('./utils');
+
+function getReportFilePath(filePath) {
+  return `${path.join(getCommandLineArgs().out, filePath)}.json`;
+}
+
+/**
+ * Analyse the specified file and return the analysis report as an object.
+ * @param {string} filePath - path of the file to be analysed.
+ * @returns {Promise<Object>} - analysis report
+ */
+function analyzeOne(filePath) {
+  return fs
+    .readFile(filePath)
+    .then(buff => escomplex.analyzeModule(buff.toString()))
+    .then(report => ({ report, filePath }))
+    .catch(errorLogger('Error analyzing ', filePath));
+}
+
+function analyzeAndWriteToFile(sourceFilePath) {
+  const reportFilePath = getReportFilePath(sourceFilePath);
+  return fs.mkdir(path.dirname(reportFilePath))
+    .then(() => analyzeOne(sourceFilePath))
+    .then(passThrough(reportObject => fs.writeFile(reportFilePath, JSON.stringify(reportObject, null, 4))))
+    .catch(errorLogger('Error writing report for ', sourceFilePath, 'to', reportFilePath));
+}
+
+function aggregate(reports) {
+  return { reports };
+}
+
+function analyze(filePaths) {
+  return Promise
+    .all(filePaths.map(analyzeAndWriteToFile))
+    .then(logger('Analyzed', filePaths.length, 'files. Now aggregating reports…'))
+    .then(aggregate)
+    .then(logger('Reports aggregated.'))
+    .catch(errorLogger('Error analyzing filePaths'));
+}
+
+module.exports = { analyze };

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -3,6 +3,7 @@
  * @module fs
  */
 const fs = require('fs');
+const path = require('path');
 const glob = require('glob');
 const _ = require('lodash');
 
@@ -46,15 +47,36 @@ function writeFile(filePath, data, options = {}) {
 }
 
 function mkdir(dirPath) {
+  if (!dirPath) {
+    const e = new Error('No dirPath');
+    console.error(e.stack);
+    process.exit(1);
+  }
+
+  const parts = (Array.isArray(dirPath) ? dirPath : dirPath.split(path.sep)).filter(_.identity);
   return new Promise(function(resolve, reject) {
-    fs.mkdir(dirPath, function(err) {
+    if (!parts[0]) {
+      const e = new Error('No dirPath from ', dirPath);
+      console.error(e.stack);
+      reject(e);
+    }
+
+    fs.mkdir(parts[0], function(err) {
       if (err && err.code !== 'EEXIST') {
+        console.error('Error making directory', parts[0]);
+        console.error(err);
         reject(err);
       } else {
         resolve();
       }
     });
-  })
+  }).then(function() {
+    if (parts.length > 1) {
+      const root = parts.shift();
+      parts[0] = path.join(root, parts[0]);
+      return mkdir(parts);
+    }
+  });
 }
 
 /**

--- a/lib/get-command-line-args.js
+++ b/lib/get-command-line-args.js
@@ -1,13 +1,19 @@
 const commandLineArgs = require('command-line-args');
 
+let cliArgs;
+
 function getCommandLineArgs() {
-  return commandLineArgs([
-    { name: 'verbose', alias: 'v', type: Boolean },
-    { name: 'src', type: String, multiple: true },
-    { name: 'glob', type: String, multiple: true },
-    { name: 'out', alias: 'o', defaultValue: '.simian-complexity-data' },
-    { name: 'help' },
-  ]);
+  if (!cliArgs) {
+    cliArgs = commandLineArgs([
+      { name: 'verbose', alias: 'v', type: Boolean },
+      { name: 'src', alias: 's', type: String, multiple: true },
+      { name: 'glob', alias: 'g', type: String, multiple: true },
+      { name: 'out', alias: 'o', defaultValue: '.simian-complexity-data' },
+      { name: 'help', type: Boolean },
+    ]);
+  }
+
+  return cliArgs;
 }
 
 module.exports = { getCommandLineArgs };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,11 @@
-const escomplex = require('escomplex');
+// const escomplex = require('escomplex');
 const _ = require('lodash');
-const path = require('path');
 const fs = require('./fs');
-const utils = require('./utils');
+const { analyze } = require('./analyze');
 const { getCommandLineArgs } = require('./get-command-line-args');
 const { printUsageGuide } = require('./print-usage-guide');
 
-const escomplexOpts = {};
+// const escomplexOpts = {};
 
 const cliArgs = getCommandLineArgs();
 
@@ -29,8 +28,6 @@ fs.mkdir(cliArgs.out)
   .then(() => fs.expandGlobs(cliArgs.glob))
   .then(filePathsFromGlob => _.uniq(sources.concat(filePathsFromGlob)))
   .then(ensureInputs)
-  .then(filePaths => Promise.all(filePaths.map(utils.toSourceObject)))
-  .then(sourceObjects => escomplex.analyse(sourceObjects, escomplexOpts))
-  .then(report => fs.writeFile(path.join(cliArgs.out, 'escomplex-output.json'), JSON.stringify(report)))
-  .then(() => console.log('All done!'))
-  .catch(err => console.error('Error occurred.', err));
+  .then(analyze)
+  .then(reports => console.log('All done!', reports))
+  .catch(err => console.error('Error occurred.', err, err.stack));

--- a/lib/print-usage-guide.js
+++ b/lib/print-usage-guide.js
@@ -9,14 +9,14 @@ function printUsageGuide(errMessage) {
   const sections = [
     {
       header: 'Simian Complexity CLI',
-      content: 'Execute escomplex and save results to disk.',
+      content: ['🐒 JavaScript static analysis using typhonjs-escomplex'],
     },
     {
       header: 'Usage',
       content: [
-        'simian-complexity -o complexity-data --glob somedir/**/*.js',
-        'simian-complexity -o complexity-data --glob somedir/**/*.js --glob someOtherDir/**/*.js',
-        'simian-complexity -o complexity-data --src somedir/*.js --src someOtherDir/*.js',
+        'simian-complexity -o complexity-data -g somedir/**/*.js',
+        'simian-complexity -o complexity-data -g somedir/**/*.js -g someOtherDir/**/*.js',
+        'simian-complexity -o complexity-data -s somedir/*.js -s someOtherDir/*.js',
       ],
     },
     {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,15 +1,73 @@
-const fs = require('./fs');
+const isLoggingEnabled = true; // this may be controlled in the future by the verbose flag.
 
-function toSourceObject(path) {
-  return fs
-    .readFile(path)
-    .then(function(buff) {
-      const code = buff.toString();
-      return {
-        code,
-        path,
-      };
-    });
+/**
+ * Given fn, returns a new function fnA such that,
+ * fnA(a) {
+ *   fn(a);
+ *   return a;
+ * }
+ * 
+ * Useful for promise handling.
+ *
+ * @param {function} fn - a function.
+ * @returns {function} - another function as described in the description.
+ */
+function passThrough(fn) {
+  return function(x) {
+    fn(x);
+    return x;
+  }
 }
 
-module.exports = { toSourceObject };
+
+/**
+ * Returns a function that will accept an error object, log it to console.error
+ * along with pre-supplied messages, and then throw the error.
+ * 
+ * This is useful when dealing with promises.
+ *
+ * @param {...*} varArgs - optional parameters to be passed to console.error.
+ * @returns {function} - a function that accepts an error and throws it.
+ */
+function errorLogger() {
+  const args = Array.from(arguments);
+  return function(err) {
+    console.error.apply(console, args.concat([err]));  // eslint-disable-line no-console
+    return err;
+  }
+}
+
+/**
+ * To log promise steps. Returns a function that will print the desired message, along with the
+ * promise resolution (optionally).
+ *
+ * @param {...*} varArgs - any messages; optionally, the last param can be an object of the form
+ *   { isLoggerConfig: true, shouldPrintArgument: (true|false) }.
+ * @returns {function} - A function.
+ */
+function logger() {
+  const args = Array.from(arguments);
+  let loggerConfig;
+  // Handle the situation where we want to specify logger configuration as the last argument
+  if (args.length && args[args.length - 1].isLoggerConfig) {
+    loggerConfig = args.pop();
+  } else {
+    loggerConfig = {};
+  }
+
+  const shouldPrintArgument = loggerConfig.shouldPrintArgument;
+
+  return function(arg) {
+    if (isLoggingEnabled) {
+      const consoleArgs = shouldPrintArgument ? args.concat[arg] : args;
+      console.log.apply(console, consoleArgs);  // eslint-disable-line no-console
+    }
+    return arg;
+  }
+}
+
+module.exports = {
+  errorLogger,
+  logger,
+  passThrough,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simian-complexity-cli",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -145,6 +145,11 @@
         }
       }
     },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -214,11 +219,6 @@
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
-    "check-types": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/check-types/-/check-types-5.1.0.tgz",
-      "integrity": "sha1-NzlN07YEKlEVXpJsOpF1PUmeXcg="
-    },
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
@@ -281,6 +281,11 @@
         "table-layout": "0.4.3",
         "typical": "2.6.1"
       }
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -365,12 +370,37 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
-    "escomplex": {
-      "version": "2.0.0-alpha",
-      "resolved": "https://registry.npmjs.org/escomplex/-/escomplex-2.0.0-alpha.tgz",
-      "integrity": "sha1-/Wp5hl2br1fEw+0bL+Z3cU5ElgY=",
+    "escomplex-plugin-metrics-module": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/escomplex-plugin-metrics-module/-/escomplex-plugin-metrics-module-0.0.13.tgz",
+      "integrity": "sha1-uj/ir5obBi3uDhMJO3HtOJodcWg=",
       "requires": {
-        "check-types": "5.1.0"
+        "typhonjs-escomplex-commons": "0.0.16"
+      }
+    },
+    "escomplex-plugin-metrics-project": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/escomplex-plugin-metrics-project/-/escomplex-plugin-metrics-project-0.0.13.tgz",
+      "integrity": "sha1-cDSXc/DEsZPVjyHqEDLRN1vvD0U=",
+      "requires": {
+        "typhonjs-escomplex-commons": "0.0.16"
+      }
+    },
+    "escomplex-plugin-syntax-babylon": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/escomplex-plugin-syntax-babylon/-/escomplex-plugin-syntax-babylon-0.0.13.tgz",
+      "integrity": "sha1-bh8pnyAR1IfdK0rOtxQ4SKC/23I=",
+      "requires": {
+        "escomplex-plugin-syntax-estree": "0.0.13",
+        "typhonjs-escomplex-commons": "0.0.16"
+      }
+    },
+    "escomplex-plugin-syntax-estree": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/escomplex-plugin-syntax-estree/-/escomplex-plugin-syntax-estree-0.0.13.tgz",
+      "integrity": "sha1-/BKGZxuMpo8fC4Abc2SwNBgvIUU=",
+      "requires": {
+        "typhonjs-escomplex-commons": "0.0.16"
       }
     },
     "eslint": {
@@ -1241,6 +1271,55 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "typhonjs-ast-walker": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/typhonjs-ast-walker/-/typhonjs-ast-walker-0.1.1.tgz",
+      "integrity": "sha1-gUVUptrSnhyyy2K8io6GwXTBaOM="
+    },
+    "typhonjs-escomplex": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/typhonjs-escomplex/-/typhonjs-escomplex-0.0.12.tgz",
+      "integrity": "sha1-wrDlpzOdeG3d03R7FT5/ZDPx/iA=",
+      "requires": {
+        "babylon": "6.18.0",
+        "commander": "2.15.1",
+        "typhonjs-escomplex-module": "0.0.12",
+        "typhonjs-escomplex-project": "0.0.12"
+      }
+    },
+    "typhonjs-escomplex-commons": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/typhonjs-escomplex-commons/-/typhonjs-escomplex-commons-0.0.16.tgz",
+      "integrity": "sha1-5oTo3ITTxsyVmKbb1hS3A/hqfUk="
+    },
+    "typhonjs-escomplex-module": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/typhonjs-escomplex-module/-/typhonjs-escomplex-module-0.0.12.tgz",
+      "integrity": "sha1-xZm7PeKzj/LYMmJa7iwgXxUxvmE=",
+      "requires": {
+        "escomplex-plugin-metrics-module": "0.0.13",
+        "escomplex-plugin-syntax-babylon": "0.0.13",
+        "typhonjs-ast-walker": "0.1.1",
+        "typhonjs-escomplex-commons": "0.0.16",
+        "typhonjs-plugin-manager": "0.0.3"
+      }
+    },
+    "typhonjs-escomplex-project": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/typhonjs-escomplex-project/-/typhonjs-escomplex-project-0.0.12.tgz",
+      "integrity": "sha1-EKHWvzJ/czOKG9eHFZ/GMka5x5g=",
+      "requires": {
+        "escomplex-plugin-metrics-project": "0.0.13",
+        "typhonjs-escomplex-commons": "0.0.16",
+        "typhonjs-escomplex-module": "0.0.12",
+        "typhonjs-plugin-manager": "0.0.3"
+      }
+    },
+    "typhonjs-plugin-manager": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/typhonjs-plugin-manager/-/typhonjs-plugin-manager-0.0.3.tgz",
+      "integrity": "sha1-hN1eHQG0QRm95JPqZW3O+JJVq4Q="
     },
     "typical": {
       "version": "2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simian-complexity-cli",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "CLI for escomplex.",
   "main": "lib/index.js",
   "bin": "lib/index.js",
@@ -30,8 +30,8 @@
   "dependencies": {
     "command-line-args": "^5.0.2",
     "command-line-usage": "^5.0.5",
-    "escomplex": "^2.0.0-alpha",
     "glob": "^7.1.2",
-    "lodash": "^4.17.10"
+    "lodash": "^4.17.10",
+    "typhonjs-escomplex": "0.0.12"
   }
 }


### PR DESCRIPTION
### What was the problem?

Tool didn't support ES6.

### How this PR fixes the problem?

Uses typhonjs-escomplex to support ES6 and JSX.

### Additional Comments

Done:
- ES6 and JSX support thanks to typhonjs-escomplex.
- Fixed bug in handling --help flag.
- Updated usage guide.
- Writing individual json report files.

TODO:
- Polish around error handling and logging.
- Glob issues. OSX (or bash?) expands glob patterns unless they are enclosed in double quotes. Sadly, it doesn't do so recursively (so basically foo/**/*.js doesn't work as expected).

