### PR TITLE
Added unit tests for selectors. Tweaked selectors to use lodash.get

### DIFF
--- a/lib/selectors/method.js
+++ b/lib/selectors/method.js
@@ -1,7 +1,8 @@
+const _ = require('lodash');
 module.exports = {
-  cyclomatic        : method => method.cyclomatic || 0,
-  halsteadBugs      : method => method.halstead.bugs || 0,
-  halsteadDifficulty: method => method.halstead.difficulty || 0,
-  halsteadVolume    : method => method.halstead.volume || 0,
-  sloc              : method => method.sloc.logical || 0,
+  cyclomatic        : method => _.get(method, 'cyclomatic', 0),
+  halsteadBugs      : method => _.get(method, ['halstead', 'bugs'], 0),
+  halsteadDifficulty: method => _.get(method, ['halstead', 'difficulty'], 0),
+  halsteadVolume    : method => _.get(method, ['halstead', 'volume'], 0),
+  sloc              : method => _.get(method, ['sloc', 'logical'], 0),
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simian-complexity-cli",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "CLI for escomplex.",
   "main": "lib/index.js",
   "bin": "bin/index.js",

--- a/test/selectors/method.js
+++ b/test/selectors/method.js
@@ -1,0 +1,28 @@
+const methodSelectors = require('../../lib/selectors/method');
+const { testSelectors } = require('./test-selectors');
+describe('selectors/method', function() {
+  testSelectors(
+    methodSelectors,
+    [{
+      name: 'cyclomatic',
+      expectedPath: 'cyclomatic',
+      defaultValue: 0
+    }, {
+      name: 'halsteadBugs',
+      expectedPath: 'halstead.bugs',
+      defaultValue: 0
+    }, {
+      name: 'halsteadDifficulty',
+      expectedPath: 'halstead.difficulty',
+      defaultValue: 0
+    }, {
+      name: 'halsteadVolume',
+      expectedPath: 'halstead.volume',
+      defaultValue: 0
+    }, {
+      name: 'sloc',
+      expectedPath: 'sloc.logical',
+      defaultValue: 0
+    }],
+  );
+});

--- a/test/selectors/report.js
+++ b/test/selectors/report.js
@@ -1,0 +1,12 @@
+const reportSelectors = require('../../lib/selectors/report');
+const { testSelectors } = require('./test-selectors');
+describe('selectors/report', function() {
+  testSelectors(
+    reportSelectors,
+    [{
+      name: 'methods',
+      expectedPath: 'methods',
+      defaultValue: []
+    }],
+  );
+});

--- a/test/selectors/test-selectors.js
+++ b/test/selectors/test-selectors.js
@@ -1,0 +1,47 @@
+const assert = require('assert');
+const _ = require('lodash');
+
+/**
+ * @typedef SelectorTestDescription
+ * @property {string} name - name of the selector to be tested.
+ * @property {string} expectedPath - what path is the selector expected to select?
+ * @property {*} [defaultValue] - if present, this will be expected when the actual value is falsy.
+ */
+
+/**
+ * Generates and executes unit tests for the given selector module according to the
+ * list of testDescriptions.
+ * 
+ * @param {Object} moduleObject - The selector module to be tested.
+ * @param {SelectorTestDescription[]} testDescriptions - Test descriptions.
+ */
+function testSelectors(moduleObject, testDescriptions) {
+  testDescriptions.forEach(function(selectorDescription) {
+    const {
+      defaultValue,
+      expectedPath,
+      name,
+    } = selectorDescription;
+    const expectedVal = 'EXPECTEDVAL';
+
+    describe(name, function() {
+      const selector = moduleObject[name];
+      it('should get the value at the expected path', function () {
+        const testObj = {};
+        _.set(testObj, expectedPath, expectedVal);
+        assert.equal(selector(testObj), expectedVal);
+      });
+
+      if (typeof defaultValue !== 'undefined') {
+        it('should return default value if expected path is falsy', function () {
+          if (typeof defaultValue === 'object')
+            assert.deepEqual(selector({}), defaultValue);
+          else
+            assert.equal(selector({}), defaultValue);
+        });
+      }
+    })
+  });
+}
+
+module.exports = { testSelectors };


### PR DESCRIPTION
### What was the problem?

Selectors had no test coverage.

### How does this PR fix the problem?

Adds unit tests for selectors. Because selectors have pretty standard logic, I wrote code to auto-generate mocha tests based on test descriptions list. Test descriptions list is an array of test description objects, where each object contains the name of a selector, the path which it selects, and the default value.

### Additional Comments (if any)

Modified method selectors to use `_.get` instead of accessing the path directly.

### TODO
[x] Updated the version and the changelog.