### PR TITLE
Added unit tests for get-command-line-args.js

### DIFF
--- a/lib/cli/get-command-line-args.js
+++ b/lib/cli/get-command-line-args.js
@@ -16,6 +16,7 @@ function getCommandLineArgs() {
   } catch(err) {
     // command-line-args freaks out if called when running tests, because it
     // encounters "unknown" flags (like --recursive). Eat the errors.
+    /* istanbul ignore next */
     if(process.env.NODE_ENV === 'test') {
       return {};
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simian-complexity-cli",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "CLI for escomplex.",
   "main": "lib/index.js",
   "bin": "bin/index.js",

--- a/test/cli/get-command-line-args.js
+++ b/test/cli/get-command-line-args.js
@@ -1,0 +1,73 @@
+const assert = require('assert');
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+function disableMockery() {
+  mockery.deregisterAll();
+  mockery.disable();
+}
+
+function enableMockery() {
+  mockery.enable({
+    useCleanCache: true,
+    warnOnReplace: true,
+    warnOnUnregistered: false,
+  });
+}
+
+describe('cli/get-command-line-args', function() {
+  describe('getCommandLineArgs', function() {
+    this.beforeAll(enableMockery);
+    this.afterAll(disableMockery);
+
+    it('should maintain cliArgs as a singleton', function() {
+      const cliArgs = 42;
+      const commandLineArgs = sinon.stub().returns(cliArgs);
+      mockery.registerMock('command-line-args', commandLineArgs);
+      const { getCommandLineArgs } = require('../../lib/cli/get-command-line-args');
+
+      assert.equal(getCommandLineArgs(), cliArgs);
+      assert.equal(getCommandLineArgs(), cliArgs);
+      assert.equal(getCommandLineArgs(), cliArgs);
+
+      assert.equal(commandLineArgs.calledOnce, 1, 'commandLineArgs() should only have been called once.');
+    });
+  });
+
+  describe('getReportName', function() {
+    this.beforeEach(enableMockery);
+    this.afterEach(disableMockery);
+
+    it('should return name when provided on the cli', async function() {
+      mockery.registerMock('command-line-args', () => ({
+        name: 'fubar',
+      }));
+
+      const { getReportName } = require('../../lib/cli/get-command-line-args');
+      assert.equal(await getReportName(), 'fubar');
+    });
+
+    it('should use getCommit() when no report name is provided', async function() {
+      mockery.registerMock('command-line-args', () => ({}));
+      mockery.registerMock('../utils/git', {
+        getCommit: () => Promise.resolve('fubar')
+      });
+
+      const { getReportName } = require('../../lib/cli/get-command-line-args');
+      assert.equal(await getReportName(), 'Git:fubar');
+    });
+
+    it('should use report generation time when no report name is provided and directory is not a git repo', async function() {
+      const toTimeString = sinon.stub(Date.prototype, 'toTimeString');
+      toTimeString.returns('fubar');
+      mockery.registerMock('command-line-args', () => ({}));
+      mockery.registerMock('../utils/git', {
+        getCommit: () => Promise.reject('blah')
+      });
+
+      const { getReportName } = require('../../lib/cli/get-command-line-args');
+      assert.equal(await getReportName(), 'fubar');
+      toTimeString.restore();
+    });
+  });
+});

--- a/test/cli/get-command-line-args.js
+++ b/test/cli/get-command-line-args.js
@@ -30,7 +30,7 @@ describe('cli/get-command-line-args', function() {
       assert.equal(getCommandLineArgs(), cliArgs);
       assert.equal(getCommandLineArgs(), cliArgs);
 
-      assert.equal(commandLineArgs.calledOnce, 1, 'commandLineArgs() should only have been called once.');
+      assert.ok(commandLineArgs.calledOnce, 'commandLineArgs() should only have been called once.');
     });
   });
 

--- a/test/cli/print-usage-guide.js
+++ b/test/cli/print-usage-guide.js
@@ -28,7 +28,7 @@ describe('cli/print-usage-guide', function() {
   });
 
   it('should print usage guide when called without error', function() {
-    const consoleLog = sinon.spy(console, 'log');
+    const consoleLog = sinon.stub(console, 'log');
     printUsageGuide();
 
     assert.deepEqual(commandLineUsage.args, [[sections]]);
@@ -36,7 +36,7 @@ describe('cli/print-usage-guide', function() {
     consoleLog.restore();
   });
   it('should print error when called with error object', function() {
-    const consoleErr = sinon.spy(console, 'error');
+    const consoleErr = sinon.stub(console, 'error');
     const errMessage = 'FOO BAR BAZ';
     const testErr = new Error(errMessage);
     const expectedSections = [...sections];
@@ -53,7 +53,7 @@ describe('cli/print-usage-guide', function() {
   });
 
   it('should print error when called with error string', function() {
-    const consoleErr = sinon.spy(console, 'error');
+    const consoleErr = sinon.stub(console, 'error');
     const errMessage = 'FOO BAR BAZ';
     const expectedSections = [...sections];
     expectedSections[0] = {


### PR DESCRIPTION
### What was the problem?

Insufficient coverage for get-command-line-args.js.

### How does this PR fix the problem?

Adds unit tests for the file.

### Additional Comments (if any)

Some methods get called from other tests and show up in the coverage as covered, even though they are not actually being tested. We should address such functions in another PR.

### TODO
- [X] Updated the version and the changelog.