### PR TITLE
Weighted averages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ simian-complexity-data
 .nyc_output
 coverage/
 .DS_Store
-test-run.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
-node_modules/
+.DS_Store
+.nyc_output
 .simian-complexity-data
-simian-complexity-data
 .vscode/
 *.log
-.nyc_output
 coverage/
-.DS_Store
+node_modules/
+simian-complexity-data
+test-run.sh

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ simian-complexity-data
 .nyc_output
 coverage/
 .DS_Store
+test-run.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+## 3.0.0 (10/10/2018; Akshat Sharma)
+- We now calculate weighted average of the metrics we care about.
+
 ## 2.2.1 (8/12/2018; Akshat Sharma)
--  Lots of tests.
+- Lots of tests.
 
 ## 2.2.0 (7/25/2018; Akshat Sharma)
 - Report files now contain dependency information. Set up testing and stuff.

--- a/lib/aggregate/calculate-aggregates.js
+++ b/lib/aggregate/calculate-aggregates.js
@@ -1,64 +1,6 @@
 const Report = require('../selectors/report');
 const Method = require('../selectors/method');
 
-class Totals {
-  constructor() {
-    this.metrics = makeMetricsObject();
-    this.dependencies = {};
-    this.dependents = {};
-    this.numberOfMethods = 0;
-  }
-
-  updateDependencies(dependency, dependent) {
-    let dependencies = this.dependencies[dependent];
-    if (!dependencies) {
-      dependencies = this.dependencies[dependent] = new Set();
-    }
-    dependencies.add(dependency);
-
-    let dependents = this.dependents[dependency];
-    if (!dependents) {
-      dependents = this.dependents[dependency] = new Set();
-    }
-    dependents.add(dependent);
-  }
-
-  getDependenciesMap() {
-    const dependenciesMap = {};
-    for(let dependent in this.dependencies) {
-      dependenciesMap[dependent] = Array.from(this.dependencies[dependent]);
-    }
-    return dependenciesMap;
-  }
-
-  getDependentsMap() {
-    const dependentsMap = {};
-    for (let dependency in this.dependents) {
-      dependentsMap[dependency] = Array.from(this.dependents[dependency]);
-    }
-    return dependentsMap;
-  }
-
-  getWeights(dependents) {
-    const weights = {};
-    for (let dependency in dependents) {
-      weights[dependency] = dependents[dependency].length;
-    }
-    return weights;
-  }
-
-  summarize() {
-    const dependents = this.getDependentsMap();
-    return {
-      ...this.metrics,
-      dependencies: this.getDependenciesMap(),
-      dependents,
-      numberOfMethods: this.numberOfMethods,
-      weights: this.getWeights(dependents),
-    };
-  }
-}
-
 function makeMetricsObject() {
   return {
     cyclomatic: 0,
@@ -71,34 +13,22 @@ function makeMetricsObject() {
   };
 }
 
-function makeTotalsObject() {
-  return new Totals();
-}
-
 function calculateTotals(reports) {
-  const total = makeTotalsObject();
+  const total = makeMetricsObject();
   total.numberOfMethods = 0;
-  reports.forEach(function({ filePath, report }) {
+  reports.forEach(function({ report }) {
     const methods = Report.methods(report);
     total.numberOfMethods += methods.length;
     methods.forEach(function (method) {
-      const { metrics } = total;
-      metrics.halstead.bugs += Method.halsteadBugs(method);
-      metrics.halstead.difficulty += Method.halsteadDifficulty(method);
-      metrics.halstead.volume += Method.halsteadVolume(method);
-      metrics.cyclomatic += Method.cyclomatic(method);
-      metrics.sloc += Method.sloc(method);
-    });
-
-    report.dependencies.forEach(dependencyInfo => {
-      const dependency = dependencyInfo.path;
-      const dependent = filePath;
-      total.updateDependencies(dependency, dependent);
-      total.updateDependencies(dependency, dependent);
+      total.halstead.bugs += Method.halsteadBugs(method);
+      total.halstead.difficulty += Method.halsteadDifficulty(method);
+      total.halstead.volume += Method.halsteadVolume(method);
+      total.cyclomatic += Method.cyclomatic(method);
+      total.sloc += Method.sloc(method);
     });
   });
 
-  return total.summarize();
+  return total;
 }
 
 function calculateAverages(total) {
@@ -126,5 +56,4 @@ function calculateAggregates(reports = []) {
 module.exports = {
   calculateAggregates,
   makeMetricsObject,
-  makeTotalsObject,
 };

--- a/lib/aggregate/calculate-aggregates.js
+++ b/lib/aggregate/calculate-aggregates.js
@@ -13,8 +13,10 @@ function makeMetricsObject() {
   };
 }
 
-function reducer({ total, average }, { report }) {
-  if (report) {
+function calculateTotals(reports) {
+  const total = makeMetricsObject();
+  total.numberOfMethods = 0;
+  reports.forEach(function({ report }) {
     const methods = Report.methods(report);
     total.numberOfMethods += methods.length;
     methods.forEach(function (method) {
@@ -24,38 +26,34 @@ function reducer({ total, average }, { report }) {
       total.cyclomatic += Method.cyclomatic(method);
       total.sloc += Method.sloc(method);
     });
+  });
 
-    const numMethods = total.numberOfMethods;
-    average.cyclomatic = total.cyclomatic / numMethods
-    average.sloc = total.sloc / numMethods;
-    average.halstead.bugs = total.halstead.bugs / numMethods;
-    average.halstead.difficulty = total.halstead.difficulty / numMethods;
-    average.halstead.volume = total.halstead.volume / numMethods;
-  }
+  return total;
+}
+
+function calculateAverages(total) {
+  const average = makeMetricsObject();
+  const numMethods = total.numberOfMethods;
+  average.cyclomatic = numMethods ? total.cyclomatic / numMethods : 0
+  average.sloc = numMethods ? total.sloc / numMethods : 0;
+  average.halstead.bugs = numMethods ? total.halstead.bugs / numMethods : 0;
+  average.halstead.difficulty = numMethods ? total.halstead.difficulty / numMethods : 0;
+  average.halstead.volume = numMethods ? total.halstead.volume / numMethods : 0;
+
+  return average;
+}
+
+function calculateAggregates(reports = []) {
+  const total = calculateTotals(reports);
+  const average = calculateAverages(total);
 
   return {
     total,
-    average,
+    average
   };
-}
-
-/*
-TODO: Now that we are getting dependencies, let us use a weighted average instead of simple average to aggregate metrics.
-*/
-function calculateAggregates(reports = []) {
-  const total = {
-    ...makeMetricsObject(),
-    numberOfMethods: 0,
-  };
-
-  const average = makeMetricsObject();
-
-  reports.reduce(reducer, { total, average });
-  return { total, average };
 }
 
 module.exports = {
   calculateAggregates,
   makeMetricsObject,
-  reducer,
 };

--- a/lib/aggregate/calculate-aggregates.js
+++ b/lib/aggregate/calculate-aggregates.js
@@ -1,59 +1,165 @@
+const path = require('path');
 const Report = require('../selectors/report');
 const Method = require('../selectors/method');
+const cli = require('../cli/');
+
+function add(initialValue = 0) {
+  let value = initialValue;
+  return function (increment = 0) {
+    value += increment;
+    return value;
+  }
+}
+
+function weightedAverage() {
+  const denominator = add();
+  const numerator = add();
+  let average = 0;
+  return function(value = 0, weight = 0) {
+    if (weight) {
+      average = numerator(value * weight) / denominator(weight);
+    }
+    return average;
+  }
+}
 
 function makeMetricsObject() {
   return {
-    cyclomatic: 0,
-    sloc: 0,
+    cyclomatic: add(),
+    sloc: add(),
+    numberOfMethods: add(),
     halstead: {
-      bugs: 0,
-      difficulty: 0,
-      volume: 0,
+      bugs: add(),
+      difficulty: add(),
+      volume: add(),
     }
   };
 }
 
-function calculateTotals(reports) {
+function makeAverage() {
+  return {
+    cyclomatic: weightedAverage(),
+    sloc: weightedAverage(),
+    halstead: {
+      bugs: weightedAverage(),
+      difficulty: weightedAverage(),
+      volume: weightedAverage(),
+    }
+  };
+}
+
+function withoutExtension(str) {
+  return str.replace(/(.jsx?|.ts)?$/, '');
+}
+
+const getAbsoluteDependencyPath = function (projectRoot, sourceFilePath, dependencyPath) {
+  if (dependencyPath.charAt(0) === '.') {
+    const sourceFileDirectory = path.dirname(sourceFilePath);
+    const res = path.resolve(sourceFileDirectory, dependencyPath);
+    return withoutExtension(path.relative(projectRoot, res));
+  }
+
+  return withoutExtension(dependencyPath);
+};
+
+function getWeights(reports) {
+  const weights = {};
+  for(let { filePath, report } of reports) {
+    const { dependencies } = report;
+    for (let dependency of dependencies) {
+      if (dependency.path.charAt(0) !== '.') {
+        continue;
+      }
+      const dependencyPath = getAbsoluteDependencyPath(cli.getSourceDirectoryPath(), filePath, dependency.path);
+      weights[dependencyPath] = (weights[dependencyPath] || 0) + 1;
+    }
+  }
+
+  return weights;
+}
+
+function getReportTotals(report) {
   const total = makeMetricsObject();
-  total.numberOfMethods = 0;
-  reports.forEach(function({ report }) {
-    const methods = Report.methods(report);
-    total.numberOfMethods += methods.length;
-    methods.forEach(function (method) {
-      total.halstead.bugs += Method.halsteadBugs(method);
-      total.halstead.difficulty += Method.halsteadDifficulty(method);
-      total.halstead.volume += Method.halsteadVolume(method);
-      total.cyclomatic += Method.cyclomatic(method);
-      total.sloc += Method.sloc(method);
-    });
+  const methods = Report.methods(report);
+  total.numberOfMethods(methods.length);
+  methods.forEach(function(method) {
+    total.cyclomatic(Method.cyclomatic(method));
+    total.halstead.bugs(Method.halsteadBugs(method));
+    total.halstead.difficulty(Method.halsteadDifficulty(method));
+    total.halstead.volume(Method.halsteadVolume(method));
+    total.sloc(Method.sloc(method));
   });
 
   return total;
 }
 
-function calculateAverages(total) {
-  const average = makeMetricsObject();
-  const numMethods = total.numberOfMethods;
-  average.cyclomatic = numMethods ? total.cyclomatic / numMethods : 0
-  average.sloc = numMethods ? total.sloc / numMethods : 0;
-  average.halstead.bugs = numMethods ? total.halstead.bugs / numMethods : 0;
-  average.halstead.difficulty = numMethods ? total.halstead.difficulty / numMethods : 0;
-  average.halstead.volume = numMethods ? total.halstead.volume / numMethods : 0;
+function evaluate(obj) {
+  if (typeof obj === 'function') {
+    return obj();
+  }
 
-  return average;
+  if (Array.isArray(obj)) {
+    return obj.forEach(evaluate);
+  }
+
+  if (typeof obj === 'object') {
+    return Object.keys(obj).reduce(
+      (acc, key) => ({ ...acc, [key]: evaluate(obj[key]) }),
+      {}
+    );
+  }
+
+  return obj;
 }
 
 function calculateAggregates(reports = []) {
-  const total = calculateTotals(reports);
-  const average = calculateAverages(total);
+  const total = makeMetricsObject();
+  const average = makeAverage();
+  const weightedAverage = makeAverage();
+  const weights = getWeights(reports);
+  const details = {};
+
+  reports.forEach(function(report) {
+    const reportPath = withoutExtension(path.relative(cli.getSourceDirectoryPath(), report.filePath));
+    const weight = weights[reportPath] || 0;
+    const reportTotal = getReportTotals(report.report);
+
+    details[reportPath] = {
+      weight,
+      ...evaluate(reportTotal),
+    };
+
+    total.sloc(reportTotal.sloc());
+    total.numberOfMethods(reportTotal.numberOfMethods());
+    total.cyclomatic(reportTotal.cyclomatic());
+    total.halstead.bugs(reportTotal.halstead.bugs());
+    total.halstead.difficulty(reportTotal.halstead.difficulty());
+    total.halstead.volume(reportTotal.halstead.volume());
+
+    average.sloc(reportTotal.sloc(), 1);
+    average.cyclomatic(reportTotal.cyclomatic(), 1);
+    average.halstead.bugs(reportTotal.halstead.bugs(), 1);
+    average.halstead.difficulty(reportTotal.halstead.difficulty(), 1);
+    average.halstead.volume(reportTotal.halstead.volume(), 1);
+
+    weightedAverage.sloc(reportTotal.sloc(), weight);
+    weightedAverage.cyclomatic(reportTotal.cyclomatic(), weight);
+    weightedAverage.halstead.bugs(reportTotal.halstead.bugs(), weight);
+    weightedAverage.halstead.difficulty(reportTotal.halstead.difficulty(), weight);
+    weightedAverage.halstead.volume(reportTotal.halstead.volume(), weight);
+  });
 
   return {
-    total,
-    average
+    average: evaluate(average),
+    total: evaluate(total),
+    weightedAverage: evaluate(weightedAverage),
+    details,
   };
 }
 
 module.exports = {
+  add,
   calculateAggregates,
   makeMetricsObject,
+  weightedAverage,
 };

--- a/lib/aggregate/calculate-aggregates.js
+++ b/lib/aggregate/calculate-aggregates.js
@@ -8,10 +8,25 @@ const {
   makeMetricsObject,
 } = require('./model');
 const {
-  getAbsoluteDependencyPath,
+  getDependencyPathRelativeToProjectRoot,
   withoutExtension,
 } = require('./utils');
 
+/**
+ * Given a list of report objects (each containing a list of dependencies), returns an object
+ * mapping each source files to its _weight_, where weight is simply the number of files dependent
+ * on it. So for instance, a file that is `require()` (or imported) by 3 files will have a weight
+ * 3 (and the reports param will have at least 4 report objects with three requiring the report
+ * with the weight 3).
+ *
+ * This function only calculates weights for relative paths (as imports with absolute paths are
+ * usually in node_modules and we don't analyse them).
+ *
+ * *Note* Source file paths, the key in the returned map, is relative to the project root. 
+ *
+ * @param {Object[]} reports - A list of report objects.
+ * @returns {Object<string, number>} - A weights map as described above.
+ */
 function getWeights(reports) {
   const weights = {};
   for(let { filePath, report } of reports) {
@@ -20,7 +35,7 @@ function getWeights(reports) {
       if (dependency.path.charAt(0) !== '.') {
         continue;
       }
-      const dependencyPath = getAbsoluteDependencyPath(cli.getSourceDirectoryPath(), filePath, dependency.path);
+      const dependencyPath = getDependencyPathRelativeToProjectRoot(cli.getSourceDirectoryPath(), filePath, dependency.path);
       weights[dependencyPath] = (weights[dependencyPath] || 0) + 1;
     }
   }
@@ -28,6 +43,14 @@ function getWeights(reports) {
   return weights;
 }
 
+/**
+ * Calculates the total values of various metrics for the given report (instead of "method
+ * aggregate" or average as contained within the report object) by summing them for each
+ * method.
+ *
+ * @param {Object} report - Report
+ * @returns {Object} - An object containing totals of various metrics we care about.
+ */
 function getReportTotals(report) {
   const total = makeMetricsObject();
   const methods = Report.methods(report);
@@ -89,6 +112,7 @@ function calculateAggregates(reports = []) {
 }
 
 module.exports = {
+  evaluate,
   getWeights,
   getReportTotals,
   calculateAggregates,

--- a/lib/aggregate/calculate-aggregates.js
+++ b/lib/aggregate/calculate-aggregates.js
@@ -1,66 +1,16 @@
 const path = require('path');
 const Report = require('../selectors/report');
 const Method = require('../selectors/method');
-const cli = require('../cli/');
-
-function add(initialValue = 0) {
-  let value = initialValue;
-  return function (increment = 0) {
-    value += increment;
-    return value;
-  }
-}
-
-function weightedAverage() {
-  const denominator = add();
-  const numerator = add();
-  let average = 0;
-  return function(value = 0, weight = 0) {
-    if (weight) {
-      average = numerator(value * weight) / denominator(weight);
-    }
-    return average;
-  }
-}
-
-function makeMetricsObject() {
-  return {
-    cyclomatic: add(),
-    sloc: add(),
-    numberOfMethods: add(),
-    halstead: {
-      bugs: add(),
-      difficulty: add(),
-      volume: add(),
-    }
-  };
-}
-
-function makeAverage() {
-  return {
-    cyclomatic: weightedAverage(),
-    sloc: weightedAverage(),
-    halstead: {
-      bugs: weightedAverage(),
-      difficulty: weightedAverage(),
-      volume: weightedAverage(),
-    }
-  };
-}
-
-function withoutExtension(str) {
-  return str.replace(/(.jsx?|.ts)?$/, '');
-}
-
-const getAbsoluteDependencyPath = function (projectRoot, sourceFilePath, dependencyPath) {
-  if (dependencyPath.charAt(0) === '.') {
-    const sourceFileDirectory = path.dirname(sourceFilePath);
-    const res = path.resolve(sourceFileDirectory, dependencyPath);
-    return withoutExtension(path.relative(projectRoot, res));
-  }
-
-  return withoutExtension(dependencyPath);
-};
+const cli = require('../cli');
+const {
+  evaluate,
+  makeAverageObject,
+  makeMetricsObject,
+} = require('./model');
+const {
+  getAbsoluteDependencyPath,
+  withoutExtension,
+} = require('./utils');
 
 function getWeights(reports) {
   const weights = {};
@@ -93,29 +43,10 @@ function getReportTotals(report) {
   return total;
 }
 
-function evaluate(obj) {
-  if (typeof obj === 'function') {
-    return obj();
-  }
-
-  if (Array.isArray(obj)) {
-    return obj.forEach(evaluate);
-  }
-
-  if (typeof obj === 'object') {
-    return Object.keys(obj).reduce(
-      (acc, key) => ({ ...acc, [key]: evaluate(obj[key]) }),
-      {}
-    );
-  }
-
-  return obj;
-}
-
 function calculateAggregates(reports = []) {
   const total = makeMetricsObject();
-  const average = makeAverage();
-  const weightedAverage = makeAverage();
+  const average = makeAverageObject();
+  const weightedAverage = makeAverageObject();
   const weights = getWeights(reports);
   const details = {};
 
@@ -158,8 +89,7 @@ function calculateAggregates(reports = []) {
 }
 
 module.exports = {
-  add,
+  getWeights,
+  getReportTotals,
   calculateAggregates,
-  makeMetricsObject,
-  weightedAverage,
 };

--- a/lib/aggregate/calculate-aggregates.js
+++ b/lib/aggregate/calculate-aggregates.js
@@ -1,6 +1,64 @@
 const Report = require('../selectors/report');
 const Method = require('../selectors/method');
 
+class Totals {
+  constructor() {
+    this.metrics = makeMetricsObject();
+    this.dependencies = {};
+    this.dependents = {};
+    this.numberOfMethods = 0;
+  }
+
+  updateDependencies(dependency, dependent) {
+    let dependencies = this.dependencies[dependent];
+    if (!dependencies) {
+      dependencies = this.dependencies[dependent] = new Set();
+    }
+    dependencies.add(dependency);
+
+    let dependents = this.dependents[dependency];
+    if (!dependents) {
+      dependents = this.dependents[dependency] = new Set();
+    }
+    dependents.add(dependent);
+  }
+
+  getDependenciesMap() {
+    const dependenciesMap = {};
+    for(let dependent in this.dependencies) {
+      dependenciesMap[dependent] = Array.from(this.dependencies[dependent]);
+    }
+    return dependenciesMap;
+  }
+
+  getDependentsMap() {
+    const dependentsMap = {};
+    for (let dependency in this.dependents) {
+      dependentsMap[dependency] = Array.from(this.dependents[dependency]);
+    }
+    return dependentsMap;
+  }
+
+  getWeights(dependents) {
+    const weights = {};
+    for (let dependency in dependents) {
+      weights[dependency] = dependents[dependency].length;
+    }
+    return weights;
+  }
+
+  summarize() {
+    const dependents = this.getDependentsMap();
+    return {
+      ...this.metrics,
+      dependencies: this.getDependenciesMap(),
+      dependents,
+      numberOfMethods: this.numberOfMethods,
+      weights: this.getWeights(dependents),
+    };
+  }
+}
+
 function makeMetricsObject() {
   return {
     cyclomatic: 0,
@@ -13,22 +71,34 @@ function makeMetricsObject() {
   };
 }
 
+function makeTotalsObject() {
+  return new Totals();
+}
+
 function calculateTotals(reports) {
-  const total = makeMetricsObject();
+  const total = makeTotalsObject();
   total.numberOfMethods = 0;
-  reports.forEach(function({ report }) {
+  reports.forEach(function({ filePath, report }) {
     const methods = Report.methods(report);
     total.numberOfMethods += methods.length;
     methods.forEach(function (method) {
-      total.halstead.bugs += Method.halsteadBugs(method);
-      total.halstead.difficulty += Method.halsteadDifficulty(method);
-      total.halstead.volume += Method.halsteadVolume(method);
-      total.cyclomatic += Method.cyclomatic(method);
-      total.sloc += Method.sloc(method);
+      const { metrics } = total;
+      metrics.halstead.bugs += Method.halsteadBugs(method);
+      metrics.halstead.difficulty += Method.halsteadDifficulty(method);
+      metrics.halstead.volume += Method.halsteadVolume(method);
+      metrics.cyclomatic += Method.cyclomatic(method);
+      metrics.sloc += Method.sloc(method);
+    });
+
+    report.dependencies.forEach(dependencyInfo => {
+      const dependency = dependencyInfo.path;
+      const dependent = filePath;
+      total.updateDependencies(dependency, dependent);
+      total.updateDependencies(dependency, dependent);
     });
   });
 
-  return total;
+  return total.summarize();
 }
 
 function calculateAverages(total) {
@@ -56,4 +126,5 @@ function calculateAggregates(reports = []) {
 module.exports = {
   calculateAggregates,
   makeMetricsObject,
+  makeTotalsObject,
 };

--- a/lib/aggregate/index.js
+++ b/lib/aggregate/index.js
@@ -21,11 +21,14 @@ async function aggregate(reports) {
     gitCommit = await getCommit(getSourceDirectoryPath());
     logger.debug(`git commit is ${gitCommit}`);
   } catch(err) {
-    logger.warn('Error obtaining git hash.', err);
-    if (err.type === 'NotARepoError') {
-      gitCommit = 'not a git repo';
-    } else {
-      gitCommit = 'error obtaining git commit hash';
+    /* istanbul ignore next */
+    {
+      logger.warn('Error obtaining git hash.', err);
+      if (err.type === 'NotARepoError') {
+        gitCommit = 'not a git repo';
+      } else {
+        gitCommit = 'error obtaining git commit hash';
+      }
     }
   }
 

--- a/lib/aggregate/math.js
+++ b/lib/aggregate/math.js
@@ -1,0 +1,24 @@
+function add(initialValue = 0) {
+  let value = initialValue;
+  return function (increment = 0) {
+    value += increment;
+    return value;
+  }
+}
+
+function weightedAverage() {
+  const denominator = add();
+  const numerator = add();
+  let average = 0;
+  return function(value = 0, weight = 0) {
+    if (weight) {
+      average = numerator(value * weight) / denominator(weight);
+    }
+    return average;
+  }
+}
+
+module.exports = {
+  add,
+  weightedAverage,
+};

--- a/lib/aggregate/model.js
+++ b/lib/aggregate/model.js
@@ -1,0 +1,51 @@
+const { add, weightedAverage } = require('./math');
+
+function makeMetricsObject() {
+  return {
+    cyclomatic: add(),
+    sloc: add(),
+    numberOfMethods: add(),
+    halstead: {
+      bugs: add(),
+      difficulty: add(),
+      volume: add(),
+    }
+  };
+}
+
+function makeAverageObject() {
+  return {
+    cyclomatic: weightedAverage(),
+    sloc: weightedAverage(),
+    halstead: {
+      bugs: weightedAverage(),
+      difficulty: weightedAverage(),
+      volume: weightedAverage(),
+    }
+  };
+}
+
+function evaluate(obj) {
+  if (typeof obj === 'function') {
+    return obj();
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.forEach(evaluate);
+  }
+
+  if (typeof obj === 'object') {
+    return Object.keys(obj).reduce(
+      (acc, key) => ({ ...acc, [key]: evaluate(obj[key]) }),
+      {}
+    );
+  }
+
+  return obj;
+}
+
+module.exports = {
+  evaluate,
+  makeAverageObject,
+  makeMetricsObject,
+};

--- a/lib/aggregate/utils.js
+++ b/lib/aggregate/utils.js
@@ -1,0 +1,20 @@
+const path = require('path');
+
+function withoutExtension(str) {
+  return str.replace(/(.jsx?|.ts)?$/, '');
+}
+
+const getAbsoluteDependencyPath = function (projectRoot, sourceFilePath, dependencyPath) {
+  if (dependencyPath.charAt(0) === '.') {
+    const sourceFileDirectory = path.dirname(sourceFilePath);
+    const res = path.resolve(sourceFileDirectory, dependencyPath);
+    return withoutExtension(path.relative(projectRoot, res));
+  }
+
+  return withoutExtension(dependencyPath);
+};
+
+module.exports = {
+  getAbsoluteDependencyPath,
+  withoutExtension,
+};

--- a/lib/aggregate/utils.js
+++ b/lib/aggregate/utils.js
@@ -4,7 +4,7 @@ function withoutExtension(str) {
   return str.replace(/(.jsx?|.ts)?$/, '');
 }
 
-const getAbsoluteDependencyPath = function (projectRoot, sourceFilePath, dependencyPath) {
+const getDependencyPathRelativeToProjectRoot = function (projectRoot, sourceFilePath, dependencyPath) {
   if (dependencyPath.charAt(0) === '.') {
     const sourceFileDirectory = path.dirname(sourceFilePath);
     const res = path.resolve(sourceFileDirectory, dependencyPath);
@@ -15,6 +15,6 @@ const getAbsoluteDependencyPath = function (projectRoot, sourceFilePath, depende
 };
 
 module.exports = {
-  getAbsoluteDependencyPath,
+  getDependencyPathRelativeToProjectRoot,
   withoutExtension,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simian-complexity-cli",
-  "version": "2.2.4",
+  "version": "3.0.0",
   "description": "CLI for escomplex.",
   "main": "lib/index.js",
   "bin": "bin/index.js",

--- a/test/aggregate/calculate-aggregates.js
+++ b/test/aggregate/calculate-aggregates.js
@@ -1,76 +1,92 @@
 const assert = require('assert');
+const sinon = require('sinon');
+const mockery = require('mockery');
 const {
-  calculateAggregates,
+  evaluate,
   makeMetricsObject,
-} = require('../../lib/aggregate/calculate-aggregates');
+  makeAverageObject,
+} = require('../../lib/aggregate/model');
 
-describe('aggregate', function() {
-  describe('makeMetricsObject', function() {
-    it('should have the expected shape', function() {
-      const metricsObject = makeMetricsObject();
-      const { halstead } = metricsObject;
-      assert.strictEqual(metricsObject.cyclomatic, 0);
-      assert.strictEqual(metricsObject.sloc, 0);
-      assert.strictEqual(halstead.bugs, 0);
-      assert.strictEqual(halstead.difficulty, 0);
-      assert.strictEqual(halstead.volume, 0);
+describe('aggregate/calculateAggregates', function() {
+  const getSourceDirectoryPath = sinon.stub().returns('heckle/jeckle');
+  let calculateAggregates;
+
+  this.beforeAll(function() {
+    mockery.enable({
+      warnOnUnregistered: false
+    });
+    mockery.registerMock('../cli', { getSourceDirectoryPath });
+    calculateAggregates = require('../../lib/aggregate/calculate-aggregates').calculateAggregates;
+  });
+
+  it('should not explode when no arguments are provided', function() {
+    assert.deepEqual(calculateAggregates(), {
+      total: {
+        ...evaluate(makeMetricsObject()),
+        numberOfMethods: 0,
+      },
+      average: evaluate(makeAverageObject()),
+      weightedAverage: evaluate(makeAverageObject()),
+      details: {},
     });
   });
 
-  describe('calculateAggregates', function() {
-    it('should not explode when no arguments are provided', function() {
-      assert.deepEqual(calculateAggregates(), {
-        total: {
-          ...makeMetricsObject(),
-          numberOfMethods: 0,
-        },
-        average: makeMetricsObject(),
-      });
-    });
+  it('should calculate values', function() {
+    const testMethod = {
+      cyclomatic: 1,
+      sloc: {
+        logical: 1
+      },
+      halstead: {
+        bugs: 1,
+        difficulty: 1,
+        volume: 1,
+      },
+    };
 
-    it('should calculate values', function() {
-      const testMethod = {
-        cyclomatic: 1,
-        sloc: {
-          logical: 1
-        },
+    const testReport = {
+      methods: [
+        { ...testMethod },
+        { ...testMethod },
+        { ...testMethod },
+      ],
+      dependencies: [],
+    };
+
+    const result = calculateAggregates([{ filePath: 'foo/bar/baz.js', report: testReport }]);
+    const total = {
+      cyclomatic: 3,
+      sloc: 3,
+      halstead: {
+        bugs: 3,
+        difficulty: 3,
+        volume: 3,
+      }
+    };
+    assert.deepEqual(result, {
+      total: {
+        ...total,
+        numberOfMethods: 3,
+      },
+      average: total,
+      // For a single file, weight is 0 (the default). Which leads to weighted average being 0 as well.
+      // This is probably wrong.
+      weightedAverage: {
+        cyclomatic: 0,
+        sloc: 0,
         halstead: {
-          bugs: 1,
-          difficulty: 1,
-          volume: 1,
+          bugs: 0,
+          difficulty: 0,
+          volume: 0,
         },
-      };
-
-      const testReport = {
-        methods: [
-          { ...testMethod },
-          { ...testMethod },
-          { ...testMethod },
-        ],
-      };
-
-      const result = calculateAggregates([{ report: testReport }]);
-      assert.deepEqual(result, {
-        total: {
-          cyclomatic: 3,
-          sloc: 3,
+      },
+      details: {
+        "../../foo/bar/baz": {
+          ...total,
+          weight: 0,
           numberOfMethods: 3,
-          halstead: {
-            bugs: 3,
-            difficulty: 3,
-            volume: 3,
-          }
-        },
-        average: {
-          cyclomatic: 1,
-          sloc: 1,
-          halstead: {
-            bugs: 1,
-            difficulty: 1,
-            volume: 1,
-          },
-        },
-      });
-    })
+        }
+      }
+    });
   });
 });

--- a/test/aggregate/calculate-aggregates.js
+++ b/test/aggregate/calculate-aggregates.js
@@ -1,92 +1,187 @@
 const assert = require('assert');
 const sinon = require('sinon');
-const mockery = require('mockery');
+const path = require('path');
+const {
+  mockery,
+  enableMockery,
+  disableMockery
+} = require('../mocks/mockery');
+const { getCli } = require('../mocks/cli');
+
 const {
   evaluate,
   makeMetricsObject,
   makeAverageObject,
 } = require('../../lib/aggregate/model');
 
-describe('aggregate/calculateAggregates', function() {
-  const getSourceDirectoryPath = sinon.stub().returns('heckle/jeckle');
-  let calculateAggregates;
-
-  this.beforeAll(function() {
-    mockery.enable({
-      warnOnUnregistered: false
+describe('aggregates/calculate-aggregates', function() {
+  describe('calculateAggregates', function() {
+    const getSourceDirectoryPath = sinon.stub().returns('heckle/jeckle');
+    let calculateAggregates;
+  
+    this.beforeAll(function() {
+      enableMockery();
+      mockery.registerMock('../cli', { getSourceDirectoryPath });
+      calculateAggregates = require('../../lib/aggregate/calculate-aggregates').calculateAggregates;
     });
-    mockery.registerMock('../cli', { getSourceDirectoryPath });
-    calculateAggregates = require('../../lib/aggregate/calculate-aggregates').calculateAggregates;
-  });
 
-  it('should not explode when no arguments are provided', function() {
-    assert.deepEqual(calculateAggregates(), {
-      total: {
-        ...evaluate(makeMetricsObject()),
-        numberOfMethods: 0,
-      },
-      average: evaluate(makeAverageObject()),
-      weightedAverage: evaluate(makeAverageObject()),
-      details: {},
+    this.afterAll(function() {
+      disableMockery();
     });
-  });
-
-  it('should calculate values', function() {
-    const testMethod = {
-      cyclomatic: 1,
-      sloc: {
-        logical: 1
-      },
-      halstead: {
-        bugs: 1,
-        difficulty: 1,
-        volume: 1,
-      },
-    };
-
-    const testReport = {
-      methods: [
-        { ...testMethod },
-        { ...testMethod },
-        { ...testMethod },
-      ],
-      dependencies: [],
-    };
-
-    const result = calculateAggregates([{ filePath: 'foo/bar/baz.js', report: testReport }]);
-    const total = {
-      cyclomatic: 3,
-      sloc: 3,
-      halstead: {
-        bugs: 3,
-        difficulty: 3,
-        volume: 3,
-      }
-    };
-    assert.deepEqual(result, {
-      total: {
-        ...total,
-        numberOfMethods: 3,
-      },
-      average: total,
-      // For a single file, weight is 0 (the default). Which leads to weighted average being 0 as well.
-      // This is probably wrong.
-      weightedAverage: {
-        cyclomatic: 0,
-        sloc: 0,
-        halstead: {
-          bugs: 0,
-          difficulty: 0,
-          volume: 0,
+  
+    it('should not explode when no arguments are provided', function() {
+      assert.deepEqual(calculateAggregates(), {
+        total: {
+          ...evaluate(makeMetricsObject()),
+          numberOfMethods: 0,
         },
-      },
-      details: {
-        "../../foo/bar/baz": {
-          ...total,
-          weight: 0,
-          numberOfMethods: 3,
+        average: evaluate(makeAverageObject()),
+        weightedAverage: evaluate(makeAverageObject()),
+        details: {},
+      });
+    });
+  
+    it('should calculate values', function() {
+      const testMethod = {
+        cyclomatic: 1,
+        sloc: {
+          logical: 1
+        },
+        halstead: {
+          bugs: 1,
+          difficulty: 1,
+          volume: 1,
+        },
+      };
+  
+      const testReport = {
+        methods: [
+          { ...testMethod },
+          { ...testMethod },
+          { ...testMethod },
+        ],
+        dependencies: [],
+      };
+  
+      const result = calculateAggregates([{ filePath: 'foo/bar/baz.js', report: testReport }]);
+      const total = {
+        cyclomatic: 3,
+        sloc: 3,
+        halstead: {
+          bugs: 3,
+          difficulty: 3,
+          volume: 3,
         }
+      };
+      assert.deepEqual(result, {
+        total: {
+          ...total,
+          numberOfMethods: 3,
+        },
+        average: total,
+        // For a single file, weight is 0 (the default). Which leads to weighted average being 0 as well.
+        // This is probably wrong.
+        weightedAverage: {
+          cyclomatic: 0,
+          sloc: 0,
+          halstead: {
+            bugs: 0,
+            difficulty: 0,
+            volume: 0,
+          },
+        },
+        details: {
+          "../../foo/bar/baz": {
+            ...total,
+            weight: 0,
+            numberOfMethods: 3,
+          }
+        }
+      });
+    });
+  });
+
+  describe('getWeights', function() {
+    const sourceDirectoryPath = 'test-source-directory-path';
+    const cli = getCli({ sourceDirectoryPath });
+    let getWeights;
+
+    this.beforeAll(function() {
+      enableMockery();
+      mockery.registerMock('../cli', cli);
+      getWeights = require('../../lib/aggregate/calculate-aggregates').getWeights;
+    });
+    this.afterAll(disableMockery);
+
+    it('should return weights', function() {
+      const reports = [{
+        filePath: path.join(sourceDirectoryPath, 'src', 'foo'),
+        report: { dependencies: []}
+      }, {
+        filePath: path.join(sourceDirectoryPath, 'src', 'bar'),
+        report: { dependencies: [{path: './foo'}]}
+      }, {
+        filePath: path.join(sourceDirectoryPath, 'src', 'baz'),
+        report: { dependencies: [{path: './foo'}, {path: './bar'}]}
+      }, {
+        filePath: path.join(sourceDirectoryPath, 'src', 'qux'),
+        report: {
+          dependencies: [
+            { path: './foo' },
+            { path: './bar' },
+            { path: './baz' },
+            { path: 'this-absolute-path-should-be-ignored' }
+          ]
+        }
+      }];
+
+      const actualWeights = getWeights(reports);
+      const expectedWeights = {
+        'src/foo': 3,
+        'src/bar': 2,
+        'src/baz': 1
+      };
+      assert.deepEqual(actualWeights, expectedWeights);
+    });
+  });
+
+  describe('getReportTotals', function() {
+    const cli = getCli({ sourceDirectoryPath: 'blah' });
+    this.beforeAll(function() {
+      enableMockery();
+      mockery.registerMock('../cli', cli);
+    });
+    this.afterAll(disableMockery);
+
+    it('should return totals', function() {
+      const { evaluate, getReportTotals } = require('../../lib/aggregate/calculate-aggregates');
+
+      const makeMethod = (cyclomatic, bugs, difficulty, volume, sloc) => ({
+        cyclomatic,
+        sloc: { logical: sloc },
+        halstead: { bugs, difficulty, volume },
+      });
+
+      const report = {
+        methods: [
+          makeMethod(1, 2, 3, 4, 5),
+          makeMethod(10, 20, 30, 40, 50),
+          makeMethod(100, 200, 300, 400, 500),
+        ],
       }
+
+      const actualTotals = evaluate(getReportTotals(report));
+      const expectedTotals = {
+        numberOfMethods: 3,
+        cyclomatic: 111,
+        sloc: 555,
+        halstead: {
+          bugs: 222,
+          difficulty: 333,
+          volume: 444,
+        }
+      };
+      assert.deepEqual(actualTotals, expectedTotals);
     });
   });
 });

--- a/test/aggregate/calculate-aggregates.js
+++ b/test/aggregate/calculate-aggregates.js
@@ -2,7 +2,6 @@ const assert = require('assert');
 const {
   calculateAggregates,
   makeMetricsObject,
-  reducer,
 } = require('../../lib/aggregate/calculate-aggregates');
 
 describe('aggregate', function() {
@@ -28,14 +27,8 @@ describe('aggregate', function() {
         average: makeMetricsObject(),
       });
     });
-  });
 
-  describe('reducer', function() {
-    it('should not explode when no report is provided', function() {
-      assert.deepEqual(reducer({ total: {}, average: {}}, {}), { total: {}, average: {}});
-    });
-
-    it('update totals', function() {
+    it('should calculate values', function() {
       const testMethod = {
         cyclomatic: 1,
         sloc: {
@@ -56,9 +49,7 @@ describe('aggregate', function() {
         ],
       };
 
-      const total = { ...makeMetricsObject(), numberOfMethods: 0 };
-      const average = makeMetricsObject();
-      const result = reducer({ total, average }, { report: testReport });
+      const result = calculateAggregates([{ report: testReport }]);
       assert.deepEqual(result, {
         total: {
           cyclomatic: 3,

--- a/test/aggregate/model.js
+++ b/test/aggregate/model.js
@@ -1,0 +1,20 @@
+const assert = require('assert');
+const {
+  evaluate,
+  makeMetricsObject,
+} = require('../../lib/aggregate/model');
+
+
+describe('aggregate/model', function() {
+  describe('makeMetricsObject', function() {
+    it('should have the expected shape', function() {
+      const metricsObject = evaluate(makeMetricsObject());
+      const { halstead } = metricsObject;
+      assert.strictEqual(metricsObject.cyclomatic, 0);
+      assert.strictEqual(metricsObject.sloc, 0);
+      assert.strictEqual(halstead.bugs, 0);
+      assert.strictEqual(halstead.difficulty, 0);
+      assert.strictEqual(halstead.volume, 0);
+    });
+  });
+});


### PR DESCRIPTION
### What was the problem?

We were calculating simple average of the metrics we care about. Weighted averages, with weight being the number of other files dependent on one source file are a better measure for our application.

### How does this PR fix the problem?

Calculates and includes weighted average of the metrics.

### Additional Comments (if any)

Note that while this is an improvement, it is still not the best solution because…
1. This is weighted average across the entire codebase. We can get more accuracy by asking for a "main" file and then building the dependency tree from there.
2. We are looking at dependencies at the file level, but it would be more accurate to look at them at symbol level (though that might involve dealing with the AST directly instead of relying on ESComplex).

### TODO
[x] Updated the version and the changelog.