### PR TITLE
Simplify output directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.0 (10/10/2018; Akshat Sharma)
+- Don't put report into a subdirectory with the gitcommit/report generation time (so now only one report lives in the output directory).
+
 ## 3.0.0 (10/10/2018; Akshat Sharma)
 - We now calculate weighted average of the metrics we care about.
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,16 @@ A CLI for escomplex.
 $ npm install -g simian-complexity-cli
 ```
 
+You will need to have node > 7.6.
+
 ## Usage
 ```
 $ simian-complexity-cli "/Users/foo/git/plato" -x "\/test\/" -x "Gruntfile"
 ```
 
-This will output JSON files corresponding to each js and jsx files in `/Users/foo/git/plato`, while excluding `/test/`, and `Gruntfile`. The output will be placed in `/Users/foo/git/plato/simian-complexity-data/Git:<git commit hash>`.
+This will output JSON files corresponding to each js and jsx files in `/Users/foo/git/plato`, while excluding `/test/`, and `Gruntfile`. The output will be placed in `/Users/foo/git/plato/simian-complexity-data/` (but you can specify the output location using the --out flag).
+
+We will also place an aggregatation of various complexity metrics (continaing total, average, and weighted average values) into the same directory as `simian-aggregated-report.json`.
 
 Since this is still evolving, command line switches may change. You can always see the latest usage guide by executing
 ```

--- a/lib/utils/get-report-directory.js
+++ b/lib/utils/get-report-directory.js
@@ -1,21 +1,8 @@
-const { getCommit, NotARepoError } = require('./git');
 const path = require('path');
 const {
   getOutputDirectoryPath,
   getSourceDirectoryPath,
-  reportGenerationTime,
 } = require('../cli');
-
-async function getOutputDirectoryIdentifier() {
-  try {
-    const commit = await getCommit();
-    return `Git:${commit}`;
-  } catch (err) {
-    if (err instanceof NotARepoError) {
-      return `Time:${reportGenerationTime}`;
-    }
-  }
-}
 
 /**
  * @param {string} filePath - path of a single file.
@@ -29,16 +16,13 @@ async function getReportFilePath(filePath) {
     throw new Error(`[getReportFilePath] Unexpected filePath >${filePath}< does not start with rootPath >${rootPath}<`);
 
   const choppedFilePath = filePath.substr(rootPath.length);
-  const outputDirectoryId = await getOutputDirectoryIdentifier();
   const stub = path.join(
     getOutputDirectoryPath(),
-    outputDirectoryId,
     choppedFilePath
   );
   return `${stub}.json`;
 }
 
 module.exports = {
-  getOutputDirectoryIdentifier,
   getReportFilePath,
 };

--- a/package.json
+++ b/package.json
@@ -20,11 +20,14 @@
     "CLI"
   ],
   "author": "akshat.sh@gmail.com",
-  "license": "MIT",
+  "license": "GPL-2.0-only",
   "bugs": {
     "url": "https://github.com/akshat1/simian-complexity-cli/issues"
   },
   "homepage": "https://github.com/akshat1/simian-complexity-cli#readme",
+  "engines": {
+    "node": ">=8.0"
+  },
   "devDependencies": {
     "codecov": "^3.0.4",
     "eslint": "^4.19.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "rm -rf ./simian-complexity-data"
   },
   "repository": {
-    "type": "MIT",
+    "type": "git",
     "url": "git+https://github.com/akshat1/simian-complexity-cli.git"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "simian-complexity-cli",
-  "version": "3.0.0",
-  "description": "CLI for escomplex.",
+  "version": "4.0.0",
+  "description": "JS complexity analysis",
   "main": "lib/index.js",
   "bin": "bin/index.js",
   "scripts": {

--- a/test/utils/get-report-directory.js
+++ b/test/utils/get-report-directory.js
@@ -45,42 +45,4 @@ describe('utils/get-report-directory', function() {
     assert.ok(rejectedForNoPath);
     assert.ok(rejectedForInvalidPath);
   });
-
-  it('should work correctly when source directory is a git directory', async function () {
-    const gitHash = '112358132134';
-    const outputDirPath = 'output';
-    mockery.registerMock('../cli', {
-      getSourceDirectoryPath: () => '/FOO/BAR',
-      getOutputDirectoryPath: () => outputDirPath,
-    });
-    mockery.registerMock('./git', {
-      getCommit: () => Promise.resolve(gitHash)
-    });
-
-    const { getReportFilePath } = require('../../lib/utils/get-report-directory');
-    assert.equal(
-      await getReportFilePath('/FOO/BAR/BAZ/QUX.js'),
-      `${outputDirPath}/Git:${gitHash}/BAZ/QUX.js.json`,
-    );
-  });
-
-  it('should work correctly when source directory is not a git directory', async function () {
-    const reportGenerationTime = '112358132134';
-    const outputDirPath = 'output';
-    mockery.registerMock('../cli', {
-      getSourceDirectoryPath: () => '/FOO/BAR',
-      getOutputDirectoryPath: () => outputDirPath,
-      reportGenerationTime,
-    });
-    mockery.registerMock('./git', {
-      getCommit: () => Promise.reject(new NotARepoError('blah')),
-      NotARepoError,
-    });
-
-    const { getReportFilePath } = require('../../lib/utils/get-report-directory');
-    assert.equal(
-      await getReportFilePath('/FOO/BAR/BAZ/QUX.js'),
-      `${outputDirPath}/Time:${reportGenerationTime}/BAZ/QUX.js.json`,
-    );
-  })
 });


### PR DESCRIPTION
The scope of this tool becomes more focused with this PR, by getting rid of the sub-directory structure where we placed the output of each run into a subdirectory, with the name being the git commit or the timestamp.

We used to do this with the idea that eventually we would add the ability to aggregate across runs. You would output into the same directory when executing the cli and get a trend report, the way you do with plato.

I have decided to move away from this idea. Instead, there will be a separate tool to generate that trend. That aligns better with the philosophy of "Do One Thing and Do It Well", and simplifies the code for this repo.